### PR TITLE
Exit if there is no new_owner.

### DIFF
--- a/i3blocks_mpris.py
+++ b/i3blocks_mpris.py
@@ -163,9 +163,10 @@ class MPRISBlocklet:
         self.connect_to_name_owner_changed_signal()
         try:
             self._loop.run()
-        except KeyboardInterrupt:
-            pass
+        except KeyboardInterrupt as e:
+            raise e
         finally:
+            self._bus.close()
             self.stop_stdin_read_loop()
 
     def start_stdin_read_loop(self):


### PR DESCRIPTION
This change is heavily influenced by how browser based music players behave.

At least on chrome and firefox, players have random names and once they are terminated (either the browser stops / restarts or in the case of firefox if all playing tabs disappear) there is no guarantee that once it is started again it will keep the same name.

A bash script wrapper for i3blocks-mpris can work around a disappearing player by doing something around the lines of:

```sh
config_path="$1"
while [ true ]; do
    player="$(playerctl -l | head -1)"
    if [ -z "${player}" ]; then
        echo "No player (yet)" && sleep 1
	continue
    fi
    i3blocks-mpris -p "$player" -c "${config_path}"
done
```

But for that to work i3blocks-mpris needs to exit once the player has disappeared.

Note: Also tried subscribing to org.freedesktop.DBus.Local.Disconnected https://dbus.freedesktop.org/doc/dbus-java/api/org/freedesktop/DBus.Local.Disconnected.html but it was not being triggered when force-killing the browsers.